### PR TITLE
Bugfix non prUrl to comment

### DIFF
--- a/handler/eventHandler.js
+++ b/handler/eventHandler.js
@@ -232,7 +232,7 @@ class EventHandler {
     const commentData = {
       commentUrl: payload.comment?.html_url,
       mentionedGitName: payload.issue?.user.login ?? payload.pull_request?.user.login,
-      prUrl: payload.pull_request?.html_url,
+      prUrl: payload.pull_request?.html_url ?? payload.issue?.html_url,
       commentAuthorGitName: payload.comment?.user.login,
       commentBody: payload.comment?.body,
       prTitle: payload.issue?.title ?? payload.pull_request?.title,


### PR DESCRIPTION
드래프트된 pr에 코멘트 남겼을 때, url링크가 undefined로 되는걸 수정합니다.